### PR TITLE
Skip the terminating UTF-8 NULL character

### DIFF
--- a/src/groot2_formatter.cpp
+++ b/src/groot2_formatter.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
   groot2::CustomXmlPrinter printer;
   doc.Print(&printer);
 
-  std::string out(printer.CStr(), printer.CStrSize());
+  std::string out(printer.CStr(), printer.CStrSize() - 1);
 
   if(result.count("output"))
   {


### PR DESCRIPTION
### Issue
The XML files generated by this tool contain non-text (i.e. the UTF-8 NULL character) at the end of the file. This confuses some text editors (such as VS Code) in inferring the type of the file.

### Cause
The `tinyxml2::XMLPrinter::CStrSize()` [includes a terminating NULL](https://github.com/leethomason/tinyxml2/blob/312a8092245df393db14a0b2427457ed2ba75e1b/tinyxml2.h#L2315) at the end of the XML file.

### Fix
Ignore the terminating UTF-8 NULL character by reducing the `tinyxml2::XMLPrinter::CStrSize()` by 1 when creating a string to be written to disk